### PR TITLE
Ignore error when release doesn't match any existing milestone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+prepare-release

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ on: release
 ## Usage
 
 ```yaml
-uses: adlerhsieh/prepare-release@v0.1.0
+uses: adlerhsieh/prepare-release@v0.1.1
 env: 
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  REPO_OWNER: ''
-  REPO: ''
+  REPO_OWNER: 'adlerhsieh'
+  REPO: 'prepare-release'
+  IGNORE_MILESTONE_NOT_FOUND: false
 ```
 
 ## Development

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,4 @@ go 1.13
 require (
 	github.com/google/go-github/v30 v30.1.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	google.golang.org/appengine v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github/v30 v30.1.0 h1:VLDx+UolQICEOKu2m4uAoMti1SxuEBAl7RSEG16L+Oo=
 github.com/google/go-github/v30 v30.1.0/go.mod h1:n8jBpHl45a/rlBUtRJMOG4GhNADUQFEufcolZ95JfU8=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/main.go
+++ b/main.go
@@ -7,7 +7,11 @@ import (
 
 func main() {
 	ctx := context.Background()
-	client := NewGitHubClient(ctx)
+	client, err := NewGitHubClient(ctx)
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+
 	tagName, err := client.GetLatestReleaseTag(ctx)
 	if err != nil {
 		log.Fatalln(err.Error())


### PR DESCRIPTION
This allows to set a new environment variable that when true makes the action not to fail when there is no milestones matching the tag/release. If it's not passed, the behavior it's the same as it was before.

What do you think @adlerhsieh ?