### PR TITLE
Resolve configuration in main file instead of read env vars from everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ on: release
 uses: adlerhsieh/prepare-release@v0.1.2
 env: 
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  REPO_OWNER: 'adlerhsieh'
-  REPO: 'prepare-release'
   IGNORE_MILESTONE_NOT_FOUND: false
 ```
 

--- a/github_client.go
+++ b/github_client.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/google/go-github/v30/github"
 	"golang.org/x/oauth2"
@@ -18,23 +17,13 @@ type GitHubClient struct {
 	ignoreMilestoneNotFound bool
 }
 
-func NewGitHubClient(ctx context.Context) (*GitHubClient, error) {
-	var ignoreMilestoneNotFound bool
-	var err error
-	ignoreMilestoneNotFoundEnv := os.Getenv("IGNORE_MILESTONE_NOT_FOUND")
-
-	if ignoreMilestoneNotFoundEnv != "" {
-		ignoreMilestoneNotFound, err = strconv.ParseBool(ignoreMilestoneNotFoundEnv)
-		if err != nil {
-			return &GitHubClient{}, err
-		}
-	}
+func NewGitHubClient(ctx context.Context, repoOwner, repoName string, ignoreMilestoneNotFound bool) *GitHubClient {
 	return &GitHubClient{
-		repoOwner:               os.Getenv("REPO_OWNER"),
-		repoName:                os.Getenv("REPO"),
+		repoOwner:               repoOwner,
+		repoName:                repoName,
 		client:                  newGitHubClient(ctx),
 		ignoreMilestoneNotFound: ignoreMilestoneNotFound,
-	}, nil
+	}
 }
 
 func newGitHubClient(ctx context.Context) *github.Client {

--- a/main.go
+++ b/main.go
@@ -2,15 +2,32 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log"
+	"os"
+	"strconv"
+	"strings"
 )
 
 func main() {
 	ctx := context.Background()
-	client, err := NewGitHubClient(ctx)
-	if err != nil {
-		log.Fatalln(err.Error())
+
+	repository := strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")
+	if len(repository) != 2 {
+		log.Fatalln(errors.New(fmt.Sprintf("GITHUB_REPOSITORY env var should be in the format 'octocat/hello-world', got %#q", os.Getenv("GITHUB_REPOSITORY"))))
 	}
+
+	var ignoreMilestoneNotFound bool
+	if os.Getenv("IGNORE_MILESTONE_NOT_FOUND") != "" {
+		var err error
+		ignoreMilestoneNotFound, err = strconv.ParseBool(os.Getenv("IGNORE_MILESTONE_NOT_FOUND"))
+		if err != nil {
+			log.Fatalln(errors.New(fmt.Sprintf("IGNORE_MILESTONE_NOT_FOUND env var should contain a boolean value, got %#q", os.Getenv("IGNORE_MILESTONE_NOT_FOUND"))))
+		}
+	}
+
+	client := NewGitHubClient(ctx, repository[0], repository[1], ignoreMilestoneNotFound)
 
 	tagName, err := client.GetLatestReleaseTag(ctx)
 	if err != nil {


### PR DESCRIPTION
This _cleans_ other files from reading the environment, centralizing the configuration in the main file.
Also changes the required environment variables. There is [a built-in env var](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables) that already contains the repository.